### PR TITLE
[DOC] Add conda install command

### DIFF
--- a/docs/chapters/setup/localprocess.rst
+++ b/docs/chapters/setup/localprocess.rst
@@ -27,6 +27,8 @@ Install the cdsdashboards package in the hub environment:
 ::
 
     pip install cdsdashboards
+    # or
+    conda install -c conda-forge cdsdashboards
 
 
 Also install in the user environment, with some extra dependencies:
@@ -34,6 +36,8 @@ Also install in the user environment, with some extra dependencies:
 ::
 
     pip install cdsdashboards[user]
+    # or
+    conda install -c conda-forge cdsdashboards-singleuser
 
 
 The key package for the hub environment is cdsdashboards itself; for the user environment the crucial package is jhsingle-native-proxy.
@@ -47,6 +51,8 @@ Jupyter notebooks to non-technical users:
 ::
 
     pip install voila
+    # or
+    conda install -c conda-forge voila
 
 If you plan to make use of Streamlit dashboards, also :code:`pip install streamlit` in the user environment. 
 For Plotly Dash, also run :code:`pip install dash`, etc.
@@ -69,6 +75,10 @@ comment or delete the other.**
     # Replacement for SystemdSpawner
     #c.JupyterHub.spawner_class = 'cdsdashboards.hubextension.spawners.variablesystemd.VariableSystemdSpawner'
     #c.SystemdSpawner.unit_name_template = 'jupyter-{USERNAME}{DASHSERVERNAME}'
+
+After setting the spawner, you need to specify those options:
+
+::
 
     c.JupyterHub.allow_named_servers = True
 


### PR DESCRIPTION
Hey,

The all stack is almost on conda-forge:
https://github.com/conda-forge/jhsingle-native-proxy-feedstock
https://github.com/conda-forge/bokeh-root-cmd-feedstock
https://github.com/conda-forge/plotlydash-tornado-cmd-feedstock
https://github.com/conda-forge/cdsdashboards-feedstock

Still missing r-shiny command:
https://github.com/conda-forge/staged-recipes/pull/12075

And I don't like to add `voila-materialstream` as package should be as unitary as possible.

Two questions/comments:
- Would you like to be added as maintainer on the conda recipes? This normally only means to accept bot PR when a new version is out on pypi.org - with maybe the need to update dependencies.
- I follow the logic of jupyterhub for naming the conda packages; i.e. `cdsdashboards` and `cdsdashboards-singleuser`.
- I took the liberty to split the jupyterhub config into two blocks of code as it tricks me when I set this package up; missing the part that were common settings.