### PR TITLE
Add API endpoint to list user available dashboards

### DIFF
--- a/cdsdashboards/hubextension/__init__.py
+++ b/cdsdashboards/hubextension/__init__.py
@@ -8,7 +8,7 @@ from jupyterhub.handlers.static import CacheControlStaticFilesHandler
 from .main import AllDashboardsHandler, DashboardEditHandler, MainViewDashboardHandler, ClearErrorDashboardHandler, UpgradeDashboardsHandler
 from .events import ProgressDashboardHandler
 from .._data import DATA_FILES_PATH
-from .api import DashboardAPIHandler
+from .api import DashboardsAPIHandler, DashboardAPIHandler
 
 
 cds_extra_handlers = [
@@ -25,6 +25,7 @@ cds_extra_handlers = [
 
     (r'dashboards-static/(.*)', CacheControlStaticFilesHandler, dict(path=os.path.join(DATA_FILES_PATH, 'static'))),
 
+    (r'dashboards-api', DashboardsAPIHandler),
     (r'dashboards-api/(?P<dashboard_urlname>[^/]+?)', DashboardAPIHandler),
     (r'dashboards-api/(?P<dashboard_urlname>[^/]+?)/progress', ProgressDashboardHandler),
 

--- a/cdsdashboards/hubextension/api.py
+++ b/cdsdashboards/hubextension/api.py
@@ -35,7 +35,7 @@ class DashboardsAPIHandler(DashboardBaseAPIHandler):
         body = {"_owned": list(map(to_json, my_dashboards))}
 
         visitor_dashboard_groups = self.get_visitor_dashboards(current_user)
-        for username, dashboards in visitor_dashboard_groups:
+        for username, dashboards in visitor_dashboard_groups.items():
             body[username] = list(map(to_json, dashboards))
 
         self.set_status(200)

--- a/cdsdashboards/hubextension/api.py
+++ b/cdsdashboards/hubextension/api.py
@@ -1,14 +1,45 @@
+import json
+
 from tornado.web import authenticated, HTTPError
 
 from jupyterhub.apihandlers.base import APIHandler
 
 from ..orm import Dashboard
-from .base import DashboardBaseMixin
+from .base import DashboardBaseMixin, check_database_upgrade
 from ..app import BuildersStore
 
 
 class DashboardBaseAPIHandler(APIHandler, DashboardBaseMixin):
     pass
+
+
+class DashboardsAPIHandler(DashboardBaseAPIHandler):
+
+    @authenticated
+    @check_database_upgrade
+    async def get(self):
+        """Return the list of dashboards for the current user."""
+
+        current_user = await self.get_current_user()
+
+        def to_json(dashboard):
+            return {
+                "name": dashboard.name,
+                "url": "{}hub/dashboards/{}".format(self.settings['base_url'], dashboard.urlname),
+                "description": dashboard.description,
+                "path": dashboard.start_path,
+                "username": dashboard.user.name
+            }
+
+        my_dashboards = current_user.dashboards_own
+        body = {"_owned": list(map(to_json, my_dashboards))}
+
+        visitor_dashboard_groups = self.get_visitor_dashboards(current_user)
+        for username, dashboards in visitor_dashboard_groups:
+            body[username] = list(map(to_json, dashboards))
+
+        self.set_status(200)
+        self.finish(json.dumps(body))
 
 
 class DashboardAPIHandler(DashboardBaseAPIHandler):


### PR DESCRIPTION
This add a API endpoint to list the dashboards available for the current users -> the idea is to add them in the JupyterLab launcher to increase their visibility.

> Note: I'm unsure about the need of `check_database_upgrade`