### PR TITLE
Added extension class for SudoSpawner

### DIFF
--- a/cdsdashboards/hubextension/spawners/variablesudospawner.py
+++ b/cdsdashboards/hubextension/spawners/variablesudospawner.py
@@ -1,0 +1,7 @@
+from sudospawner import SudoSpawner
+
+from .variablemixin import VariableMixin, MetaVariableMixin
+
+
+class VariableSudoSpawner(SudoSpawner, VariableMixin, metaclass=MetaVariableMixin):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ extras_require = {
         'bokeh-root-cmd>=0.0.5',
         'rshiny-server-cmd>=0.0.2',
         'voila-materialstream>=0.2.6' # Does not install voila itself
+    ],
+    'sudospawner': [
+        "sudospawner>=0.5.2"
     ]
 }
 


### PR DESCRIPTION
I wanted to use the SudoSpawner in combination with cdsdashboards. This extension class was required for that.

Configuration is exactly the same as the LocalProcessSpawner, i.e. you need to specify the correct spawner class in `jupyterhub_config.py`.

