### PR TITLE
DOC: rm line in updating jupyterhub-traefik-proxy

### DIFF
--- a/docs/chapters/setup/tljh.rst
+++ b/docs/chapters/setup/tljh.rst
@@ -30,9 +30,7 @@ Install the cdsdashboards package in the hub environment:
 ::
 
     sudo -E /opt/tljh/hub/bin/python3 -m pip install cdsdashboards
-    sudo -E /opt/tljh/hub/bin/python3 -m pip install --upgrade jupyterhub-traefik-proxy
 
-The last line is just an upgrade to a package used by TLJH that causes problems if you have an old version.
 
 Also install cdsdashboards in the user environment, including extra dependencies:
 


### PR DESCRIPTION
See https://github.com/jupyterhub/the-littlest-jupyterhub/blob/main/setup.py#L21

You should get the latest `jupyterhub-traefik-proxy` on installing tljh (https://github.com/jupyterhub/traefik-proxy/tags)

<img width="889" alt="Screen Shot 2021-12-29 at 10 11 05 AM" src="https://user-images.githubusercontent.com/17162724/147676278-86f39ab6-410c-4caf-ba31-4f7013caba41.png">
